### PR TITLE
Fix/use new s3 folder structure

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -19,6 +19,8 @@ type s3Loader struct {
 	config s3Config
 }
 
+const financialInstrumentsFolderName = "financial-instruments"
+
 func news3Loader(c s3Config) (s3Loader, error) {
 	s3Client, err := minio.New(c.domain, c.accKey, c.secretKey, true)
 	if err != nil {
@@ -42,10 +44,15 @@ func (s3Loader *s3Loader) LoadResource(path string) (io.ReadCloser, error) {
 		date   time.Time
 	}{}
 
-	for object := range s3Client.ListObjects(s3Loader.config.bucket, path, true, doneCh) {
+	for object := range s3Client.ListObjects(s3Loader.config.bucket, financialInstrumentsFolderName, true, doneCh) {
 		if object.Err != nil {
 			return nil, object.Err
 		}
+
+		if !strings.Contains(object.Key, path) {
+			continue
+		}
+
 		if !strings.Contains(object.Key, path) || strings.Contains(object.Key, "md5") {
 			continue
 		}

--- a/loader.go
+++ b/loader.go
@@ -53,10 +53,6 @@ func (s3Loader *s3Loader) LoadResource(path string) (io.ReadCloser, error) {
 			continue
 		}
 
-		if !strings.Contains(object.Key, path) || strings.Contains(object.Key, "md5") {
-			continue
-		}
-
 		dateFromName := r.FindStringSubmatch(object.Key)
 		if len(dateFromName) == 0 {
 			warnLogger.Printf("Ignoring file [%s]. Cannot parse name.", object.Key)

--- a/service_test.go
+++ b/service_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 type transformerMock struct {
-	mockTransform func() (map[string]financialInstrument, error)
+	mockTransform             func() (map[string]financialInstrument, error)
 	mockCheckConnectivityToS3 func() error
 }
 
@@ -14,7 +14,7 @@ func (tm *transformerMock) Transform() (map[string]financialInstrument, error) {
 	return tm.mockTransform()
 }
 
-func (tm *transformerMock) checkConnectivityToS3 () error {
+func (tm *transformerMock) checkConnectivityToS3() error {
 	return tm.mockCheckConnectivityToS3()
 }
 

--- a/transformer.go
+++ b/transformer.go
@@ -2,10 +2,9 @@ package main
 
 import (
 	"crypto/md5"
+	"github.com/pborman/uuid"
 	"io"
 	"time"
-
-	"github.com/pborman/uuid"
 )
 
 const secToFIGIs = "sym_bbg"


### PR DESCRIPTION
updated financial-instruments-transformer service to work with the new folder structure of financial instruments from S3